### PR TITLE
Extension policies

### DIFF
--- a/.github/workflows/teams-notification.yml
+++ b/.github/workflows/teams-notification.yml
@@ -1,0 +1,21 @@
+name: teams-notification
+
+on:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Send message to MS Teams
+        uses: dhollerbach/actions.send-message-to-ms-teams@1.0.10
+        env:
+          TEAMS_WEB_HOOK: ${{ secrets.TEAMSWEBHOOK }}
+        if: "${{ env.TEAMS_WEB_HOOK != '' }}"
+        with:
+          webhook: ${{ secrets.TEAMSWEBHOOK }}
+          message: 'New changes in the GitHub Data Product Specification'

--- a/.github/workflows/test-compliancy.yml
+++ b/.github/workflows/test-compliancy.yml
@@ -1,0 +1,24 @@
+name: test-compliancy
+
+on:
+  push:
+    branches:
+      - '**'
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.18
+    - name: Install Cue
+      run: |
+        go install cuelang.org/go/cmd/cue@latest
+
+    - name: Test
+      run: cue vet example.yaml data-product-specification.cue

--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ This repository wants to define an open specification to define data products wi
 
 With an open specification it will be possible to create services for automatic deployment and interoperable components to build a Data Mesh platform.
 
+## Version 0.0.1
 
-# Data Product structure
+## Data Product structure
 
 The Data Product is composed by a general section with Data Product level information and four sub-structures describing components:
 * **Output Ports**: representing all the different interfaces of the Data Product to expose the data to consumers
@@ -21,24 +22,24 @@ The fixed structure must be technology agnostic. The first fields of teh fixed s
 
 ### General
 
-* `ID: [String]` the unique identifier of the Data Product. This will never change in the life of a Data Product.
+* `ID: [String]*` the unique identifier of the Data Product. This will never change in the life of a Data Product.
   Constraints:
   * allowed characters are `[a-zA-Z0-9]` and `[_-]`
   * the ID is a URN of the form `urn:dmb:dp:$DPDomain:$DPName:$DPMajorVersion`
-* `Name: [String]` the name of the Data Product. This name is used also for display purposes, so it can contain all kind of characters. When used inside the Data Product ID all special characters are replaced with standard ones and spaces are replaced with dashes.
+* `Name: [String]*` the name of the Data Product. This name is used also for display purposes, so it can contain all kind of characters. When used inside the Data Product ID all special characters are replaced with standard ones and spaces are replaced with dashes.
 * `FullyQualifiedName: [Option[String]]` human-readable name that describes the Data Product.
 * `Description: [String]` detailed description about what functional area this Data Product is representing, what purpose has and business related information.
-* `Kind: [String]` type of the entity. Since this is a Data Product the only allowed value is `dataproduct`.
-* `Domain: [String]` the identifier of the domain this Data Product is belonging to.
-* `Version: [String]` this is representing the version of the Data Product. Displayed as `X.Y.Z` where X is the major version, Y is the minor version, and Z is the patch. Major version (X) is also shown in the Data Product ID and those fields (version and ID) must always be aligned with one another. We consider a Data Product as an indipendent unit of deployment, so if a breaking change is needed, we create a brand new version of it by chaning the major version. If we introduce a new feature (or patch) we will not create a new major version, but we can just change Y (new feature) or Z patch, thus not creating a new ID (and hence not creating a new Data Product).
+* `Kind: [String]*` type of the entity. Since this is a Data Product the only allowed value is `dataproduct`.
+* `Domain: [String]*` the identifier of the domain this Data Product is belonging to.
+* `Version: [String]*` this is representing the version of the Data Product. Displayed as `X.Y.Z` where X is the major version, Y is the minor version, and Z is the patch. Major version (X) is also shown in the Data Product ID and those fields (version and ID) must always be aligned with one another. We consider a Data Product as an indipendent unit of deployment, so if a breaking change is needed, we create a brand new version of it by chaning the major version. If we introduce a new feature (or patch) we will not create a new major version, but we can just change Y (new feature) or Z patch, thus not creating a new ID (and hence not creating a new Data Product).
   Constraints:
   * Major version of the Data Product is always the same as the major version of all of its components ,and it is the same version that is shown in both Data Product ID and component IDs.
-* `Environment: [String]`: logical environment where the Data Product will be deployed.
+* `Environment: [String]*`: logical environment where the Data Product will be deployed.
 * `DataProductOwner: [String]` Data Product owner, the unique identifier of the actual user that owns, manages, and receives notifications about the Data Product. To make it technology independent it is usually the email address of the owner.
 * `DataProductOwnerDisplayName [String]`: the human readable version of `DataProductOwner`.
 * `Email: [Option[String]]` point of contact between consumers and maintainers of the Data Product. It could be the owner or a distribution list, but must be reliable and responsive.
-* `OwnerGroup [String]`: LDAP user/group that is owning the data product
-* `DevGroup [String]`: LDAP user/group that is in charge to develop and maintain the data product
+* `OwnerGroup [String]`: LDAP user/group that is owning the data product.
+* `DevGroup [String]`: LDAP user/group that is in charge to develop and maintain the data product.
 * `InformationSLA: [Option[String]]` describes what SLA the Data Product team is providing to answer additional information requests about the Data Product itself.
 * `Status: [Option[String]]` this is an enum representing the status of this version of the Data Product. Allowed values are: `[Draft|Published|Retired]`. This is a metadata that communicates the overall status of the Data Product but is not reflected to the actual deployment status.
 * `Maturity: [Option[String]]` this is an enum to let the consumer understand if it is a tactical solution or not. It is really useful during migration from Data Warehouse or Data Lake. Allowed values are: `[Tactical|Strategic]`.
@@ -51,22 +52,22 @@ The **unique identifier** of a Data Product is the concatenation of Domain, Name
 
 ### Output Ports
 
-* `ID: [String]` the unique identifier of the Output Port component. This will never change in the life of a Data Product or the component itself.
+* `ID: [String]*` the unique identifier of the Output Port component. This will never change in the life of a Data Product or the component itself.
   Constraints:
   * allowed characters are `[a-zA-Z0-9]` and `[_-]`.
   * the ID is a URN of the form `urn:dmb:cmp:$DPDomain:$DPName:$DPMajorVersion:$OutputPortName`.
-* `Name: [String]` the name of the Output Port. This name is used also for display purposes, so it can contain all kind of characters. When used inside the Output Port ID all special characters are replaced with standard ones and spaces are replaced with dashes.
+* `Name: [String]*` the name of the Output Port. This name is used also for display purposes, so it can contain all kind of characters. When used inside the Output Port ID all special characters are replaced with standard ones and spaces are replaced with dashes.
 * `FullyQualifiedName: [Option[String]]` human-readable name that describes better the Output Port. It can also contain specific details (if this is a table this field could contain also indications regarding the databse and the schema).
 * `Description: [String]` detailed explanation about the function and the meaning of the output port.
-* `Kind: [String]` type of the entity. Since this is an Output Port the only allowed value is `outputport`.
-* `Version: [String]` specific version of the output port. Displayed as `X.Y.Z` where X is the major version of the Data Product, Y is the minor feature and Z is the patch. Major version (X) is also shown in the component ID and those fields( version and ID) are always aligned with one another. Please note that the major version of the component *must always* corresponde to the major version of the Data Product it belongs to.
+* `Kind: [String]*` type of the entity. Since this is an Output Port the only allowed value is `outputport`.
+* `Version: [String]*` specific version of the output port. Displayed as `X.Y.Z` where X is the major version of the Data Product, Y is the minor feature and Z is the patch. Major version (X) is also shown in the component ID and those fields( version and ID) are always aligned with one another. Please note that the major version of the component *must always* corresponde to the major version of the Data Product it belongs to.
 Constraints:
   * Major version of the Data Product is always the same as the major version of all of its components and it is the same version that is shown in both Data Product ID and component ID.
-* `InfrastructureTemplateId: [String]` the id of the microservice responsible for provisioning the component. A microservice may be capable of provisioning several components generated from different use case templates. 
-* `UseCaseTemplateId: [Option[String]]` the id of the template used in the builder to create the component. Could be empty in case the component was not created from a builder template.
-* `DependsOn: [Array[String]]` An output port could depend on other output ports or storage areas, for example a SQL Output port could be dependent on a Raw Output Port because it is just an external table.
+* `InfrastructureTemplateId: [String]*` the id of the microservice responsible for provisioning the component. A microservice may be capable of provisioning several components generated from different use case templates. 
+* `UseCaseTemplateId: [Option[String]]*` the id of the template used in the builder to create the component. Could be empty in case the component was not created from a builder template.
+* `DependsOn: [Array[String]]*` A component could depend on other components belonging to the same Data Product, for example a SQL Output port could be dependent on a Raw Output Port because it is just an external table. This is also used to define the provisioning order among components.
 Constraints:
-  * This array will only contain IDs of other components.
+  * This array will only contain IDs of other components of the same Data Product.
 * `Platform: [Option[String]]` represents the vendor: Azure, GCP, AWS, CDP on AWS, etc. It is a free field but it is useful to understand better the platform where the component will be running.
 * `Technology: [Option[String]]` represents which technology is used to define the output port, like: Athena, Impala, Dremio, etc. The underlying technology is useful for the consumer to understand better how to consume the output port.
 * `OutputPortType: [String]` the kind of output port: Files, SQL, Events, etc. This should be extendible with other values, like GraphQL or others.
@@ -90,26 +91,29 @@ Constraints:
   * `LifeCycle: [Option[String]]` Describe how the data will be historicized and how and when it will be deleted.
   * `Confidentiality: [Option[String]]` Describe what a consumer should do to keep the information confidential, how to process and store it. Permission to share or report it.
 * `Tags: [Array[Yaml]]` Tag labels at OutputPort level, here we can have security classification for example (please refer to OpenMetadata https://docs.open-metadata.org/metadata-standard/schemas/types/taglabel).
-* `SampleData: [Option[Yaml]]` provides a sample data of your Output Port. See OpenMetadata specification: https://docs.open-metadata.org/openmetadata/schemas/entities/table#tabledata
+* `SampleData: [Option[Yaml]]` provides a sample data of your Output Port (please refer to  OpenMetadata specification: https://docs.open-metadata.org/metadata-standard/schemas/entities/table#tabledata).
 * `SemanticLinking: [Option[Yaml]]` here we can express semantic relationships between this output port and other outputports (also coming from other domains and data products). For example we could say that column "customerId" of our SQL Output Port references the column "id" of the SQL Output Port of the "Customer" Data Product.
 * `Specific: [Yaml]` this is a custom section where we must put all the information strictly related to a specific technology or dependent from a standard/policy defined in the federated governance.
 
 
 ### Workloads
 
-* `ID: [String]` the unique identifier of the Workload component. This will never change in the life of a Data Product or the component itself.
+* `ID: [String]*` the unique identifier of the Workload component. This will never change in the life of a Data Product or the component itself.
   Constraints:
   * allowed characters are `[a-zA-Z0-9]` and `[_-]`.
   * the ID is a URN of the form `urn:dmb:cmp:$DPDomain:$DPName:$DPMajorVersion:$WorkloadName`.
-* `Name: [String]` the name of the Workload. This name is used also for display purposes, so it can contain all kind of characters. When used inside the Workload ID all special characters are replaced with standard ones and spaces are replaced with dashes.
+* `Name: [String]*` the name of the Workload. This name is used also for display purposes, so it can contain all kind of characters. When used inside the Workload ID all special characters are replaced with standard ones and spaces are replaced with dashes.
 * `FullyQualifiedName: [Optional[String]]` human-readable name that describes better the Workload.
 * `Description: [String]` detailed explaination about the purpose of the workload, what sources is reading, what business logic is applying, etc.
-* `Kind: [String]` type of the entity. Since this is an Output Port the only allowed value is `workload`.
-* `Version: [String]` specific version of the workload. Displayed as `X.Y.Z` where X is the major version of the Data Product, Y is the minor feature and Z is the patch. Major version (X) is also shown in the component ID and those fields( version and ID) are always aligned with one another. Please note that the major version of the component *must always* corresponde to the major version of the Data Product it belongs to.
+* `Kind: [String]*` type of the entity. Since this is an Output Port the only allowed value is `workload`.
+* `Version: [String]*` specific version of the workload. Displayed as `X.Y.Z` where X is the major version of the Data Product, Y is the minor feature and Z is the patch. Major version (X) is also shown in the component ID and those fields( version and ID) are always aligned with one another. Please note that the major version of the component *must always* corresponde to the major version of the Data Product it belongs to.
 Constraints:
   * Major version of the Data Product is always the same as the major version of all of its components and it is the same version that is shown in both Data Product ID and component ID.
-* `InfrastructureTemplateId: [String]` the id of the microservice responsible for provisioning the component. A microservice may be capable of provisioning several components generated from different use case templates. 
-* `UseCaseTemplateId: [Option[String]]` the id of the template used in the builder to create the component. Could be empty in case the component was not created from a builder template.
+* `InfrastructureTemplateId: [String]*` the id of the microservice responsible for provisioning the component. A microservice may be capable of provisioning several components generated from different use case templates. 
+* `UseCaseTemplateId: [Option[String]]*` the id of the template used in the builder to create the component. Could be empty in case the component was not created from a builder template.
+* `DependsOn: [Array[String]]*` A component could depend on other components belonging to the same Data Product, for example a SQL Output port could be dependent on a Raw Output Port because it is just an external table. This is also used to define the provisioning order among components.
+Constraints:
+  * This array will only contain IDs of other components of the same Data Product.
 * `Platform: [Option[String]]` represents the vendor: Azure, GCP, AWS, CDP on AWS, etc. It is a free field but it is useful to understand better the platform where the component will be running.
 * `Technology: [Option[String]]` represents which technology is used to define the workload, like: Spark, Flink, pySpark, etc. The underlying technology is useful to understand better how the workload process data.
 * `WorkloadType: [Option[String]]` explains what type of workload is: Ingestion ETL, Streaming, Internal Process, etc.
@@ -123,17 +127,20 @@ Constraints:
 
 ### Storage Area
 
-* `ID: [String]` the unique identifier of the Storage Area component. This will never change in the life of a Data Product or the component itself.
+* `ID: [String]*` the unique identifier of the Storage Area component. This will never change in the life of a Data Product or the component itself.
   Constraints:
   * allowed characters are `[a-zA-Z0-9]` and `[_-]`.
   * the ID is a URN of the form `urn:dmb:cmp:$DPDomain:$DPName:$DPMajorVersion:$StorageAreaName`.
-* `Name: [String]` the name of the Storage Area. This name is used also for display purposes, so it can contain all kind of characters. When used inside the Storage Area ID all special characters are replaced with standard ones and spaces are replaced with dashes.
+* `Name: [String]*` the name of the Storage Area. This name is used also for display purposes, so it can contain all kind of characters. When used inside the Storage Area ID all special characters are replaced with standard ones and spaces are replaced with dashes.
 * `FullyQualifiedName: [Optional[String]]` human-readable name that describes better the Storage Area.
 * `Description: [String]` detailed explanation about the function and the meaning of this storage area,
-* `Kind: [String]` type of the entity. Since this is an Output Port the only allowed value is `storage`.
+* `Kind: [String]*` type of the entity. Since this is an Output Port the only allowed value is `storage`.
 * `Owners: [Array[String]]` It is an array of user/role/group related to LDAP/AD user. This field defines who has all permissions on this specific storage area
-* `InfrastructureTemplateId: [String]` the id of the microservice responsible for provisioning the component. A microservice may be capable of provisioning several components generated from different use case templates. 
-* `UseCaseTemplateId: [Option[String]]` the id of the template used in the builder to create the component. Could be empty in case the component was not created from a builder template.
+* `InfrastructureTemplateId: [String]*` the id of the microservice responsible for provisioning the component. A microservice may be capable of provisioning several components generated from different use case templates. 
+* `UseCaseTemplateId: [Option[String]]*` the id of the template used in the builder to create the component. Could be empty in case the component was not created from a builder template.
+* `DependsOn: [Array[String]]*` A component could depend on other components belonging to the same Data Product, for example a SQL Output port could be dependent on a Raw Output Port because it is just an external table. This is also used to define the provisioning order among components.
+Constraints:
+  * This array will only contain IDs of other components of the same Data Product.
 * `Platform: [Option[String]]` represents the vendor: Azure, GCP, AWS, CDP on AWS, etc. It is a free field but it is useful to understand better the platform where the component will be running.
 * `Technology: [Option[String]]` represents which technology is used to define the storage area, like: S3, Kafka, Athena, etc. The underlying technology is useful to understand better how the data is internally stored.
 * `StorageType: [Option[String]]` the specific type of storage: Files, SQL, Events, etc.
@@ -146,8 +153,8 @@ Constraints:
 Observability should be applied to each Output Port and is better to represent it as the Swagger of an API rather than something declarative like a Yaml, because it will expose runtime metrics and statistics.
 Anyway is good to formalize what kind of information should be included and verified at deploy time for the observability API:
 
-* `ID: [String]` the unique identifier of the observability API
-* `Name: [String]` the name of the observability API
+* `ID: [String]*` the unique identifier of the observability API
+* `Name: [String]*` the name of the observability API
 * `FullyQualifiedName: [String]` human-readable that uniquely identifies an entity
 * `Description: [String]` detailed explanation about what this observability is exposing
 * `Endpoint: [URL]` this is the API endpoint that will expose the observability for each OutputPort
@@ -157,3 +164,61 @@ Anyway is good to formalize what kind of information should be included and veri
 * `Availability: [Yaml]`
 * `DataQuality: [Yaml]` describe data quality rules will be applied to the data, using the format you prefer.
 * `Specific: [Yaml]` this is a custom section where we can put all the information strictly related to a specific technology or dependent from a standard/policy defined in the federated governance.
+
+## Extension Points
+
+This document defines an open specification that can be customized and extended by adopters, in a way that best fits their use cases.
+Since this specification can be used as a contract between different modules not only to share metadata, but also to trigger operations and actions, we should highlight what are the points where customizations are encouraged, allowed, discouraged, or forbidden.
+
+This specification has a version (that can be found at the top of this document) that identifies it in relation with older and newer versions of it.
+In general the version should be used to notify users of the changes between the current version and the previous ones:
+- a change in the major version means that the two specification are not compatible (there are changes in names, types, and even the overall structure)
+- a change in the minor version means that there are significant changes but that will not impact compatibility (e.g. a new field is added, a mandatory field is now optional)
+- a change in the patch version means that there are no significant changes, but just bug fixes or small corrections (e.g. an improvement in the field description, a typo that was fixed, an improvement in the validation files)
+
+CUE offers also a [standard way](https://cuelang.org/docs/usecases/datadef/#validating-backwards-compatibility) to check if new versions of a schema are backwards-compatible with older versions.
+It is highly reccommended to check for schema compatibilities when multiple and/or complex changes are introduced.
+
+In the following sections we will list all the extensions and modifications of this specification and the impact they have on the overall contract:
+
+### Encouraged
+
+These changes are the ones that should always be performed in order to enrich the specification.
+Any change of this kind should just increase the minor version number.
+Encouraged customizations are:
+- definitions of the "specific" sections. These are fully customizable sections, where adopters have full control. These sections can be extended and modified to fit in the best way the use cases, so they can have also very complex structure (i.e. nested objects, nested arrays, validation rules, etc).
+- introduction of new custom metadata fields at any level. New metadata can be very useful to better explain to consumers how the Data Product and its components are structured and how they behave.
+
+### Allowed
+
+These changes are the ones that can be performed to better adapt the specification to the desired use cases.
+Any change of this kind should increase the minor version number.
+Allowed customizations are:
+- change existing metadata mandatory fields to be optional. Always think twice before performing this kind of changes, since even if this is not a breaking change, it will reduce the enforced constraints. This kind of changes can also emerge if in your use case one metadata happens to be always valued with meaningless values just to fulfill the requirement; in this case you should try to understand why this is happening and improve data entry education before acting at this level.
+- change existing metadata optional fields to be mandatory. This kind of enforcement could break compatibility of existing documents compliant to previous versions of the specification, but you could decide not to upgrade the major version since the changes to make old documents compliant are very easy to apply.
+- add additional enum values (e.g. adding a new component type, or a custom value for the Maturity field). Of course new values will not be handled, and just passed as descriptive metadata to the provisioner modules.
+
+**N.B.: all the changes described above are allowed only if they do not affect reserved fields which are treated in the Forbidden customization.**
+
+### Discouraged
+
+These changes are the ones that should not be performed since they impact compatibility with older versions.
+Any change of this kind should **always** increase the major version number.
+Discouraged customizations are:
+- change in the name or type of existing fields. This kind of change breaks compatibility with previous versions, and should be performed by keeping in mind that they will impact for sure all the logics based on those fields.
+- moving fields as sub-fields of other sections (e.g. moving the "workload type" field as a sub-field of a new "type" field). This is actually a specific case of the one above, and should be treated accordingly.
+- deletion of existing fields. This is generally somethign that will impact a lot modules that are leveraging the specification, and you must think very carefully before doing deletions. Think that you can always make a field optional, and this choice will impact the specification way less.
+
+**N.B.: all the changes described above are allowed only if they do not affect reserved fields which are treated in the Forbidden customization.**
+
+### Forbidden
+
+These changes are not allowed and you **must** always check that your changes do not fall in this category.
+Forbidden changes are the ones that affect reserved fields, that should not change in any way (name, type, structure, etc).
+All the reserved fields are highlighted with a `*` character in the specification above, like `ID: [String]*` and `Name: [String]*`.
+Since these are the fields that are usually leveraged by downstream platform modules, any change could break the agreed contract between them.
+
+## Project setup
+
+This project has an automatic GitHub action invoked every time an issue is merged into the "main" branch if a secret containing the remote web hook is set.
+If you fork this project you can set up your own Teams hook by defining a secret called "TEAMSWEBHOOK".

--- a/data-product-specification.cue
+++ b/data-product-specification.cue
@@ -1,0 +1,195 @@
+package generic_dp
+
+// All the data types that starts with OM_ are imported from OpenMetadata definitions
+
+import "strings"
+
+#Version:       string & =~"^[0-9]+\\.[0-9]+\\..+$"
+#Id:            string & =~"^[a-zA-Z0-9:._-]+$"
+#DataProductId: #Id & =~"^urn:dmb:dp:\(domain):[a-zA-Z0-9_-]+:\(majorVersion)$"
+#ComponentId:   #Id & =~"^urn:dmb:cmp:\(domain):[a-zA-Z0-9_-]+:\(majorVersion):[a-zA-Z0-9_-]+$"
+#URL:           string & =~"^https?://[a-zA-Z0-9@:%._~#=&/?]*$"
+#OM_DataType:   string & =~"(?i)^(NUMBER|TINYINT|SMALLINT|INT|BIGINT|BYTEINT|BYTES|FLOAT|DOUBLE|DECIMAL|NUMERIC|TIMESTAMP|TIME|DATE|DATETIME|INTERVAL|STRING|MEDIUMTEXT|TEXT|CHAR|VARCHAR|BOOLEAN|BINARY|VARBINARY|ARRAY|BLOB|LONGBLOB|MEDIUMBLOB|MAP|STRUCT|UNION|SET|GEOGRAPHY|ENUM|JSON)$"
+#OM_Constraint: string & =~"(?i)^(NULL|NOT_NULL|UNIQUE|PRIMARY_KEY)$"
+
+#OM_TableData: {
+	columns: [... string]
+	rows: [... [...]]
+}
+
+#OM_Tag: {
+	tagFQN:       string
+	description?: string | null
+	source:       string & =~"(?i)^(Tag|Glossary)$"
+	labelType:    string & =~"(?i)^(Manual|Propagated|Automated|Derived)$"
+	state:        string & =~"(?i)^(Suggested|Confirmed)$"
+	href?:        string | null
+}
+
+#OM_Column: {
+	name:     string
+	dataType: #OM_DataType
+	if dataType =~ "(?i)^(ARRAY)$" {
+		arrayDataType: #OM_DataType
+	}
+	if dataType =~ "(?i)^(CHAR|VARCHAR|BINARY|VARBINARY)$" {
+		dataLength: number
+	}
+	dataTypeDisplay?:    string | null
+	description?:        string | null
+	fullyQualifiedName?: string | null
+	tags?: [... #OM_Tag]
+	constraint?:      #OM_Constraint | null
+	ordinalPosition?: number | null
+	if dataType =~ "(?i)^(JSON)$" {
+		jsonSchema: string
+	}
+	if dataType =~ "(?i)^(MAP|STRUCT|UNION)$" {
+		children: [... #OM_Column]
+	}
+}
+
+#DataContract: {
+	schema: [... #OM_Column]
+	SLA: {
+		intervalOfChange?: string | null
+		timeliness?:       string | null
+		upTime?:           string | null
+		...
+	}
+	termsAndConditions?: string | null
+	endpoint?:           #URL | null
+	...
+}
+
+#DataSharingAgreement: {
+	purpose?:         string | null
+	billing?:         string | null
+	security?:        string | null
+	intendedUsage?:   string | null
+	limitations?:     string | null
+	lifeCycle?:       string | null
+	confidentiality?: string | null
+	...
+}
+
+#OutputPort: {
+	id:                       #ComponentId
+	name:                     string
+	fullyQualifiedName?:      string | null
+	description:              string
+	version:                  #Version & =~"^\(majorVersion)+\\..+$"
+	infrastructureTemplateId: string
+	useCaseTemplateId?:       string | null
+	dependsOn: [...#ComponentId]
+	platform?:            string | null
+	technology?:          string | null
+	outputPortType:       string
+	creationDate?:        string | null
+	startDate?:           string | null
+	processDescription?:  string | null
+	dataContract:         #DataContract
+	dataSharingAgreement: #DataSharingAgreement
+	tags: [... #OM_Tag]
+	sampleData?:      #OM_TableData | null
+	semanticLinking?: {...} | null
+	specific: {...}
+	...
+}
+
+#Workload: {
+	id:                       #ComponentId
+	name:                     string
+	fullyQualifiedName?:      string | null
+	description:              string
+	version:                  #Version & =~"^\(majorVersion)+\\..+$"
+	infrastructureTemplateId: string
+	useCaseTemplateId?:       string | null
+	dependsOn: [...#ComponentId]
+	platform?:       string | null
+	technology?:     string | null
+	workloadType?:   string | null
+	connectionType?: string & =~"(?i)^(housekeeping|datapipeline)$" | null
+	tags: [... #OM_Tag]
+	readsFrom: [... string]
+	specific: {...} | null
+	...
+}
+
+#Storage: {
+	id:                  #ComponentId
+	name:                string
+	fullyQualifiedName?: string | null
+	description:         string
+	version:             #Version & =~"^\(majorVersion)+\\..+$"
+	owners: [...string]
+	infrastructureTemplateId: string
+	useCaseTemplateId?:       string | null
+	dependsOn: [...#ComponentId]
+	platform?:    string | null
+	technology?:  string | null
+	storageType?: string | null
+	tags: [... #OM_Tag]
+	specific: {...} | null
+	...
+}
+
+#Observability: {
+	id:                       #ComponentId
+	name:                     string
+	fullyQualifiedName:       string
+	description:              string
+	version:                  #Version & =~"^\(majorVersion)+\\..+$"
+	infrastructureTemplateId: string
+	useCaseTemplateId?:       string | null
+	dependsOn: [...#ComponentId]
+	endpoint:      #URL
+	completeness:  {...} | null
+	dataProfiling: {...} | null
+	freshness:     {...} | null
+	availability:  {...} | null
+	dataQuality:   {...} | null
+	specific:      {...} | null
+	...
+}
+
+#Component: {
+	kind: string & =~"(?i)^(outputport|workload|storage|observability)$"
+	if kind != _|_ {
+		if kind =~ "(?i)^(outputport)$" {
+			#OutputPort
+		}
+		if kind =~ "(?i)^(workload)$" {
+			#Workload
+		}
+		if kind =~ "(?i)^(storage)$" {
+			#Storage
+		}
+		if kind =~ "(?i)^(observability)$" {
+			#Observability
+		}
+	}
+	...
+}
+
+id:                  #DataProductId
+name:                string
+fullyQualifiedName?: string | null
+description:         string
+kind:                string & =~"(?i)^(dataproduct)$"
+domain:              string
+version:             #Version
+let majorVersion = strings.Split(version, ".")[0]
+environment:                 string
+dataProductOwner:            string
+dataProductOwnerDisplayName: string
+devGroup:                    string
+ownerGroup:                  string
+email?:                      string | null
+informationSLA?:             string | null
+status?:                     string & =~"(?i)^(draft|published|retired)$" | null
+maturity?:                   string & =~"(?i)^(tactical|strategic)$" | null
+billing?:                    {...} | null
+tags: [... #OM_Tag]
+specific: {...}
+components: [#Component, ...#Component]

--- a/example.yaml
+++ b/example.yaml
@@ -1,4 +1,4 @@
-id: urn:dmb:dp:my_domain.my_data_product.1
+id: urn:dmb:dp:my_domain:my_data_product:1
 name: my data product
 fullyQualifiedName: My Data Product
 description: this data product is representing the xxx functional entity
@@ -18,7 +18,7 @@ billing: {}
 tags: []
 specific: {}
 components:
-  - id: urn:dmb:cmp:my_domain.my_data_product.1.my_raw_s3_port
+  - id: urn:dmb:cmp:my_domain:my_data_product:1:my_raw_s3_port
     name: my raw s3 port
     fullyQualifiedName: My Raw S3 Port
     description: s3 raw output port
@@ -49,14 +49,21 @@ components:
       limitations: is not possible to use this data without a compliance check
       lifeCycle: the maximum retention is 10 years, and eviction is happening on the first of january
       confidentiality: if you want to store this data somewhere else, PII columns must be masked    
-    tags: []
+    tags:
+      - tagFQN: experimental
+        source: Tag
+        labelType: Manual
+        state: Confirmed
+      - tagFQN: structured
+        source: Tag
+        labelType: Manual
+        state: Confirmed
     sampleData: {}
-    
     semanticLinking: {}
     specific:
       directory: history
       bucket: ms-datamesh-s3
-  - id: urn:dmb:cmp:my_domain.my_data_product.1.my_view_impala_port
+  - id: urn:dmb:cmp:my_domain:my_data_product:1:my_view_impala_port
     name: my view impala port
     fullyQualifiedName: My View Impala Port
     description: impala view output port
@@ -64,7 +71,7 @@ components:
     version: 1.1.0
     infrastructureTemplateId: microservice-id-2
     useCaseTemplateId: template-id-2
-    dependsOn: [urn:dmb:cmp:my_domain.my_data_product.1.my_raw_s3_port]
+    dependsOn: [urn:dmb:cmp:my_domain:my_data_product:1:my_raw_s3_port]
     platform: CDP on AWS
     technology: impala_cdp
     outputPortType: SQL
@@ -72,7 +79,11 @@ components:
     startDate:
     processDescription:
     dataContract:
-      schema: []
+      schema:
+        - name: name
+          dataType: string
+        - name: surname
+          dataType: string
       SLA:
         intervalOfChange: 1 hours
         timeliness: 1 minutes 
@@ -88,8 +99,17 @@ components:
       lifeCycle: the maximum retention is 10 years, and eviction is happening on the first of january
       confidentiality: if you want to store this data somewhere else, PII columns must be masked    
     tags: []
-    sampleData: {}
-    schema: []
+    sampleData:
+      columns:
+        - name
+        - surname
+      rows:
+        - - Jace
+          - Beleren
+        - - Gideon
+          - Jura
+        - - Chandra
+          - Nalaar
     semanticLinking: {}
     specific:
       database: my_database
@@ -99,7 +119,7 @@ components:
         firstName: string
         lastName: string
       format: PARQUET
-  - id: urn:dmb:cmp:my_domain.my_data_product.1.my_spark_workload
+  - id: urn:dmb:cmp:my_domain:my_data_product:1:my_spark_workload
     name: my spark workload
     fullyQualifiedName: My Spark workload
     description: spark batch workload
@@ -129,11 +149,15 @@ components:
       numExecutors: 3
       schedule:
         cronExpression: 0 0 0,22 ? * * *
-  - id: urn:dmb:cmp:my_domain.my_data_product.1.my_observability
+  - id: urn:dmb:cmp:my_domain:my_data_product:1:my_observability
     name: my observability
     fullyQualifiedName: My Observability
     description: observability for my data product
-    endpoint: /develop/my_domain/my_data_product/1.0.0/obs
+    kind: observability
+    infrastructureTemplateId: microservice-id-4
+    useCaseTemplateId: template-id-4
+    version: 1.1.1
+    endpoint: http://develop/my_domain/my_data_product/1.0.0/obs
     completeness:
     dataProfiling:
     freshness:


### PR DESCRIPTION
With this PR we introduced the basic rules for extending the Data Product Specification and identified a first set of "reserved" fields.
To make the specification more robust, and expose also a way for users to validate their own specifications, we introduced a CUE file that validates the example attached to the specification.